### PR TITLE
Fix bot initialization for aiogram 3.7

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -12,6 +12,7 @@ import aiohttp
 import gdown
 
 from aiogram import Bot, Dispatcher, F
+from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ParseMode
 from aiogram.exceptions import TelegramBadRequest
 from aiogram.filters import Command, CommandStart
@@ -616,7 +617,7 @@ async def main() -> None:
 
     logging.basicConfig(level=logging.INFO)
 
-    bot = Bot(token=token, parse_mode=ParseMode.HTML)
+    bot = Bot(token=token, default=DefaultBotProperties(parse_mode=ParseMode.HTML))
     dp = Dispatcher()
 
     dp.message.register(handle_start, CommandStart())


### PR DESCRIPTION
## Summary
- update Bot initialization to use DefaultBotProperties for parse mode
- import DefaultBotProperties to support aiogram 3.7 API changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc10efb87c83319c3e0d0755921a77